### PR TITLE
Added rubocop gem and config setting for Ruby v2.4.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_gem:
+  rubocop-rails_config:
+    - config/rails.yml
+AllCops:
+  TargetRubyVersion: 2.4.1

--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Adding Rubocop for Ruby syntax linting
+gem 'rubocop-rails_config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
+    ast (2.4.0)
     bindex (0.5.0)
     builder (3.2.3)
     byebug (10.0.2)
@@ -69,6 +70,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -89,7 +91,11 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
     pg (1.1.3)
+    powerpack (0.1.2)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
@@ -118,10 +124,23 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-rails_config (0.2.5)
+      railties (>= 3.0)
+      rubocop (~> 0.56)
+    ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     sass (3.5.7)
@@ -160,6 +179,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.18)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.4.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -183,6 +203,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 3.7)
   rails (~> 5.1.6)
+  rubocop-rails_config
   sass-rails (~> 5.0)
   selenium-webdriver
   spring
@@ -193,4 +214,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.3


### PR DESCRIPTION
I used the "[rubocop-rails_config](https://github.com/toshimaru/rubocop-rails_config)" gem to add rubocop linting, also ran the initializer per instructions and edited the resulting config file to match the Ruby version in the app (v2.4.1). I'm already using VSCode with that gem preinstalled in my environment by default, but I tried Sublime and it appears to be working as intended. 