### PR TITLE
Create migration to update column names in piece table to x-y coordinate positions

### DIFF
--- a/db/migrate/20181031195548_change_position_col_names.rb
+++ b/db/migrate/20181031195548_change_position_col_names.rb
@@ -1,0 +1,6 @@
+class ChangePositionColNames < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :pieces, :current_row, :x_pos
+    rename_column :pieces, :current_column, :y_pos
+  end
+end


### PR DESCRIPTION
Since we will be doing a lot of storing, checking, and calling of piece positions or positions on the board, I want to rename the "current_row" and "current_column" columns in the piece table to "x_pos" and "y_pos".