### PR TITLE
Add is_obstructed? method and helper methods to piece class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ group :development, :test do
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
   gem 'rspec-rails', '~> 3.5'
+  # Test case creation
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,11 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
+      railties (>= 3.0.0)
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -242,6 +247,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   devise
+  factory_bot_rails
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
@@ -260,4 +266,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,3 +1,5 @@
 class Bishop < Piece
-
+  def valid_move?(x_new, y_new)
+    true
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,8 +4,8 @@ class Game < ApplicationRecord
   has_many :pieces
   has_many :moves
 
-  def piece_present?(x_pos, y_pos)
-    pieces.where(x_pos: x_pos, y_pos: y_pos)
+  def piece_present(x_pos, y_pos)
+    pieces.where(x_pos: x_pos, y_pos: y_pos).first
   end
 
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,4 +3,9 @@ class Game < ApplicationRecord
   has_many :users
   has_many :pieces
   has_many :moves
+
+  def piece_present?(x_pos, y_pos)
+    pieces.where(x_pos: x_pos, y_pos: y_pos)
+  end
+
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,3 +1,5 @@
 class King < Piece
-
+  def valid_move?(x_new, y_new)
+    true
+  end
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,3 +1,5 @@
 class Knight < Piece
-
+  def valid_move?(x_new, y_new)
+    true
+  end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,4 +1,8 @@
 class Move < ApplicationRecord
   belongs_to :game
   belongs_to :piece 
+
+  def is_obstructed?
+    
+  end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -2,7 +2,4 @@ class Move < ApplicationRecord
   belongs_to :game
   belongs_to :piece 
 
-  def is_obstructed?
-    
-  end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,3 +1,5 @@
 class Pawn < Piece
-
+  def valid_move?(x_new, y_new)
+    true
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -7,8 +7,43 @@ class Piece < ApplicationRecord
     true
   end
 
-  def is_obstructed?
-    
+  def move_type(x_new, y_new)
+    # Need to deal with Knight case
+    horizontal_delta = (x_new - x_pos).abs
+    vertical_delta = (y_new - y_pos).abs
+
+    return :horizontal if horizontal_delta > 0 && vertical_delta.zero?
+    return :vertical if vertical_delta > 0 && horizontal_delta.zero?
+    return :diagonal if vertical_delta == horizontal_delta
+    return :invalid if vertical_delta > 0 && horizontal_delta > 0 && vertical_delta != horizontal_delta && type != "Knight"
+
+  end
+
+  # NOT TESTED
+  def is_obstructed?(x_new, y_new)
+    move_direction = move_type(x_new, y_new)
+    pieces_in_row = game.pieces.where(x_pos: x_new)
+    pieces_in_column = game.pieces.where(y_pos: y_new)
+    # horizontal case
+    if move_direction == :horizontal
+      obstructors = pieces_in_row.where('x_new > ? AND x_new < ?', [x_pos, x_new].min, [x_pos, x_new].max)
+      return false if obstructors.nil?
+    # vertical case
+    elsif move_direction == :vertical
+      obstructors = pieces_in_column.where('y_new > ? AND y_new < ?', [y_pos, y_new].min, [y_pos, y_new].max)
+      return false if obstructors.nil?
+    # diagonal case
+    elsif move_direction == :diagonal
+      obstructors = []
+      (x_pos..x_new).each do |x|
+        next if x == x_pos
+        break if x == x_new
+        (y_pos..y_new).each do |y|
+        next if y == y_pos
+        break if y == y_new
+          return false if game.pieces.where(x_pos: x, y_pos: y) 
+        end
+      end
     true
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -3,7 +3,9 @@ class Piece < ApplicationRecord
   belongs_to :user
   has_many :moves
 
-
+  def valid_move?(x_new, y_new)
+    true
+  end
 
   def is_obstructed?
     

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -27,23 +27,24 @@ class Piece < ApplicationRecord
     # horizontal case
     if move_direction == :horizontal
       obstructors = pieces_in_row.where('x_new > ? AND x_new < ?', [x_pos, x_new].min, [x_pos, x_new].max)
-      return false if obstructors.nil?
+      return false if obstructors.empty?
     # vertical case
-    elsif move_direction == :vertical
+    elsif move_direction == :vertical   
       obstructors = pieces_in_column.where('y_new > ? AND y_new < ?', [y_pos, y_new].min, [y_pos, y_new].max)
-      return false if obstructors.nil?
+      return false if obstructors.empty?
     # diagonal case
     elsif move_direction == :diagonal
-      obstructors = []
       (x_pos..x_new).each do |x|
         next if x == x_pos
-        break if x == x_new
+          return false if x == x_new
         (y_pos..y_new).each do |y|
-        next if y == y_pos
-        break if y == y_new
-          return false if game.pieces.where(x_pos: x, y_pos: y) 
+          next if y == y_pos
+            return true if game.pieces.where(x_pos: x, y_pos: y).size == 2 
+          end
         end
       end
-    true
+    elsif move_direction == :invalid
+      raise "Invalid move"
+    end
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -2,4 +2,11 @@ class Piece < ApplicationRecord
   belongs_to :game
   belongs_to :user
   has_many :moves
+
+
+
+  def is_obstructed?
+    
+    true
+  end
 end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,3 +1,5 @@
 class Queen < Piece
-
+  def valid_move?(x_new, y_new)
+    true
+  end
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,3 +1,5 @@
 class Rook < Piece
-
+  def valid_move?(x_new, y_new)
+    true
+  end
 end

--- a/db/migrate/20181029013105_change_piece_row_col_names.rb
+++ b/db/migrate/20181029013105_change_piece_row_col_names.rb
@@ -1,0 +1,6 @@
+class ChangePieceRowColNames < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :pieces, :current_row, :x_pos
+    rename_column :pieces, :current_column, :y_pos
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181025235307) do
+ActiveRecord::Schema.define(version: 20181029013105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,8 +43,8 @@ ActiveRecord::Schema.define(version: 20181025235307) do
     t.integer "user_id"
     t.string "type"
     t.boolean "color"
-    t.integer "current_row"
-    t.integer "current_column"
+    t.integer "x_pos"
+    t.integer "y_pos"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
The following is changed in this branch:

- Added is_obstructed? method and move_type helper method to piece class
- Added empty valid_move? methods to sub-classes that inherit from piece class, plus a final empty method to the piece class itself

I also added the FactoryBot gem, since we'll need it, but I didn't really have any way to test the logic in the is_obstructed? method. I think we will want to break that out into separate methods for each case, but need to test the underlying logic first.