### PR TITLE
Add move_to! method

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -42,19 +42,20 @@ class Piece < ApplicationRecord
     raise "Invalid move" if move_direction == :invalid
   end
 
+  # move_to! method calls valid_move? and will update a piece instance's
+  # position and/or capture by setting positions to null. Could update
+  # this later to incorporate a piece status
+
   def move_to!(x_new, y_new)
-    if game.piece_present(x_new, y_new).nil? && valid_move?(x_new, y_new)
-      update_attributes(x_pos: x_new, y_pos: y_new)
+    return raise "Invalid move" if !valid_move?(x_new, y_new)
+    occupant = game.piece_present(x_new, y_new)
+    current_piece = game.pieces.where(x_pos: x_pos, y_pos: y_pos).first
+    if occupant.nil?
+      current_piece.update_attributes(x_pos: x_new, y_pos: y_new)
+    elsif occupant.color != current_piece.color
+      current_piece.update_attributes(x_pos: x_new, y_pos: y_new)
+      occupant.update_attributes(x_pos: nil, y_pos: nil)
+    else return raise "Invalid move"
     end
   end
 end
-# This method is important and eventually, we will use it in the controller to handle moving pieces.
-
-# This move_to method should handle the following cases:
-
-#     Check to see if there is a piece in the location it’s moving to.
-#     If there is a piece occupying the location, and it is the opposite color, remove the piece from the chess board. This can be done a few different ways.
-#         You could have a “status” flag on the piece that will be one of “onboard” or “captured”. Make sure to write the appropriate migration without changing existing migrations.
-#     If the piece is there and it’s the same color the move should fail - it should either raise an error message or do nothing.
-#     It should call update_attributes on the piece and change the piece’s x/y position.
-#     Note: This method does not check if a move is valid. We will be using the valid_move? method to do that.

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -16,35 +16,45 @@ class Piece < ApplicationRecord
     return :vertical if vertical_delta > 0 && horizontal_delta.zero?
     return :diagonal if vertical_delta == horizontal_delta
     return :invalid if vertical_delta > 0 && horizontal_delta > 0 && vertical_delta != horizontal_delta && type != "Knight"
-
   end
 
-  # NOT TESTED
   def is_obstructed?(x_new, y_new)
     move_direction = move_type(x_new, y_new)
     pieces_in_row = game.pieces.where(x_pos: x_new)
     pieces_in_column = game.pieces.where(y_pos: y_new)
     # horizontal case
     if move_direction == :horizontal
-      obstructors = pieces_in_row.where('x_new > ? AND x_new < ?', [x_pos, x_new].min, [x_pos, x_new].max)
-      return false if obstructors.empty?
+      return false if pieces_in_row.where("#{x_new} > ? AND #{x_new} < ?", [x_pos, x_new].min, [x_pos, x_new].max).empty?
     # vertical case
-    elsif move_direction == :vertical   
-      obstructors = pieces_in_column.where('y_new > ? AND y_new < ?', [y_pos, y_new].min, [y_pos, y_new].max)
-      return false if obstructors.empty?
+    elsif move_direction == :vertical
+      return false if pieces_in_column.where("#{y_new} > ? AND #{y_new} < ?", [y_pos, y_new].min, [y_pos, y_new].max).empty?
     # diagonal case
     elsif move_direction == :diagonal
       (x_pos..x_new).each do |x|
         next if x == x_pos
-          return false if x == x_new
+        return false if x == x_new
         (y_pos..y_new).each do |y|
           next if y == y_pos
-            return true if game.pieces.where(x_pos: x, y_pos: y).size == 2 
-          end
+          return true if game.pieces.where(x_pos: x, y_pos: y).size == 2
         end
       end
-    elsif move_direction == :invalid
-      raise "Invalid move"
+    end
+    raise "Invalid move" if move_direction == :invalid
+  end
+
+  def move_to!(x_new, y_new)
+    if game.piece_present(x_new, y_new).nil? && valid_move?(x_new, y_new)
+      update_attributes(x_pos: x_new, y_pos: y_new)
     end
   end
 end
+# This method is important and eventually, we will use it in the controller to handle moving pieces.
+
+# This move_to method should handle the following cases:
+
+#     Check to see if there is a piece in the location it’s moving to.
+#     If there is a piece occupying the location, and it is the opposite color, remove the piece from the chess board. This can be done a few different ways.
+#         You could have a “status” flag on the piece that will be one of “onboard” or “captured”. Make sure to write the appropriate migration without changing existing migrations.
+#     If the piece is there and it’s the same color the move should fail - it should either raise an error message or do nothing.
+#     It should call update_attributes on the piece and change the piece’s x/y position.
+#     Note: This method does not check if a move is valid. We will be using the valid_move? method to do that.

--- a/db/migrate/20181029013105_change_piece_row_col_names.rb
+++ b/db/migrate/20181029013105_change_piece_row_col_names.rb
@@ -1,6 +1,0 @@
-class ChangePieceRowColNames < ActiveRecord::Migration[5.1]
-  def change
-    rename_column :pieces, :current_row, :x_pos
-    rename_column :pieces, :current_column, :y_pos
-  end
-end


### PR DESCRIPTION
This method does the following:

- Calls valid_move?
- Updates current piece instance attributes if no other piece occupies the destination square
- Or "captures" an opposing piece in the same square by updating :x_pos and :y_pos to null
- Raises errors on invalid move or attempt to move to a square occupied by a piece with the same color

I did not do anything about the piece "status" for now. Could add that later if desired, but I think the case where :x_pos and :y_pos are both nil is basically equivalent. Will keep this PR open for a bit if someone wants to comment or review.
